### PR TITLE
remove req from checkboxes

### DIFF
--- a/.github/ISSUE_TEMPLATE/osf-guest-invite.yml
+++ b/.github/ISSUE_TEMPLATE/osf-guest-invite.yml
@@ -46,9 +46,7 @@ body:
       description: Did you schedule a date for your stream?
       options:
         - label: "Yes"
-          required: true
         - label: "Not yet"
-          required: true
 
   - type: input
     id: dates_1


### PR DESCRIPTION
Resolve the reported issue in the screenshot - radiobuttons are not an option so removed the "req" field from yaml

![Screenshot 2023-10-14 at 9 59 23 AM](https://github.com/githubevents/open-source-friday/assets/47188731/afd3ce33-fc50-4b2e-b556-ad2867e33bbb)
