### PR TITLE
Sanitize variable which can be controlled by user input

### DIFF
--- a/.github/workflows/send-stream-reminder.yml
+++ b/.github/workflows/send-stream-reminder.yml
@@ -9,10 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Extract date and GitHub handle from issue body
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
         id: extract-date-and-handle
         run: |
-          DATE=$(echo '${{ github.event.issue.body }}' | grep -oP '\d{4}-\d{2}-\d{2}')
-          HANDLE=$(echo '${{ github.event.issue.body }}' | grep -oP '@\w+')
+          DATE=$(echo '$ISSUE_BODY' | grep -oP '\d{4}-\d{2}-\d{2}')
+          HANDLE=$(echo '$ISSUE_BODY' | grep -oP '@\w+')
           echo "::set-output name=date::$DATE"
           echo "::set-output name=handle::$HANDLE"
       - name: Wait until one day before date


### PR DESCRIPTION
You are using a variable which can be controlled by user input, and it may result in command execution on your runners, and secrets extraction by malicious actors.

Since the ${{ github.event.issue.body }} value can be controlled by the user who creates the issue, a malicious actor can inject system command that will run on the GitHub runner while the workflow is in progress and fetch sensitive data which stored there such as GitHub token with write permissions.

More info: https://securitylab.github.com/research/github-actions-untrusted-input/
Example for such scenario: https://github.com/githubevents/open-source-friday/actions/runs/6530510920/job/17729928317
