### PR TITLE
Fix workflow injection on issue open

### DIFF
--- a/.github/workflows/notify-guests.yml
+++ b/.github/workflows/notify-guests.yml
@@ -10,8 +10,10 @@ jobs:
     steps:
       - name: Check if stream date is not yet scheduled
         id: check-date
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
-          echo "::set-output name=not_yet::$(echo '${{ github.event.issue.body }}' | grep -q 'Not yet' && echo 'true' || echo 'false')"
+          echo "::set-output name=not_yet::$(echo '$ISSUE_BODY' | grep -q 'Not yet' && echo 'true' || echo 'false')"
       - name: Comment on issue
         if: steps.check-date.outputs.not_yet == 'true'
         uses: actions/github-script@v5


### PR DESCRIPTION
Simple fix here, the issue body is under control of other users and can be used to inject arbitrary code.

Opening a PR instead of privately reporting since this is not an official GitHub repo for the BB program.

Reference:

* https://www.praetorian.com/blog/pwn-request-hacking-microsoft-github-repositories-and-more/

