### PR TITLE
Create preguntas-generales.md

### DIFF
--- a/admin/guest-assets/preguntas-generales.md
+++ b/admin/guest-assets/preguntas-generales.md
@@ -1,0 +1,32 @@
+### Unirse a la Transmisión
+Puedes unirte a la transmisión desde este enlace:
+
+La hora oficial de inicio es: 12:00 pm, hora del este (ET). Por favor, intenta unirte 10-15 minutos (alrededor de las 11:45) antes para que podamos probar el audio, el video y el intercambio de pantalla.
+
+## Formato
+
+1. Preséntate - 5 minutos
+2. ¿Cuál es tu proyecto?
+3. ¿Qué te inspiró a crear tu proyecto o a involucrarte en su mantenimiento?
+4. Demostración - 5-15 minutos (normalmente las personas hacen una demostración sencilla de "Hola Mundo" o muestran una pequeña característica nueva que se ha añadido).
+
+#### Preguntas
+- Como mantenedor, ¿qué desafíos has enfrentado?
+- ¿Cuál ha sido la parte más gratificante de mantener un proyecto?
+- ¿Cuáles son tus ideas sobre cómo podemos mejorar la diversidad en el código abierto?
+- ¿Cómo pueden las personas contribuir a tu proyecto?
+- ¿Algún consejo para aquellos que deseen obtener más colaboradores, patrocinadores y usuarios para sus proyectos de código abierto?
+- ¿Hay preguntas de la audiencia?
+
+#### Preguntas de cierre (no técnicas):
+- ¿Cuál fue el primer lenguaje de programación que aprendiste?
+- Si el dinero no fuera un problema, ¿cómo te gustaría pasar idealmente tu tiempo? En el trabajo o no en el trabajo.
+- ¿Qué has aprendido hoy?
+- ¿Cuál es tu canción favorita de todos los tiempos?
+- ¿Qué emoji te describe mejor?
+- ¿Cuál es tu sabor de helado favorito?
+- GIF - ¿pronunciación con "g" fuerte o "g" suave?
+- Canción favorita de Beyoncé?
+- ¿Cuál es tu cosa favorita sobre el código abierto?
+
+Fin de la transmisión... no debería durar más de 45 minutos.


### PR DESCRIPTION
This pull request includes changes to the `admin/guest-assets/preguntas-generales.md` file. The changes add a new section titled "Unirse a la Transmisión" with information on how and when to join a broadcast. It also outlines the format of the broadcast, including a list of questions to be asked during the broadcast. 

The most significant changes are:

* [`admin/guest-assets/preguntas-generales.md`](diffhunk://#diff-831da88eff1884aecb465b9ea4bd794edd18b0a33cd36cdc4789a7e8d5ab6307R1-R32): Added a new section "Unirse a la Transmisión" with instructions on joining the broadcast and the official start time. Also, a new section "Formato" was added, outlining the structure of the broadcast, including a presentation, project discussion, demonstration, and a series of questions for the guest.