### PR TITLE
feat: add agentic workflow to auto-update scheduled streams table in …

### DIFF
--- a/.github/scripts/update_schedule.py
+++ b/.github/scripts/update_schedule.py
@@ -1,0 +1,196 @@
+"""
+Fetches all issues labelled 'scheduled' from the open-source-friday repo,
+parses each issue body for the guest name and stream date, looks up the host
+from the issue assignees, and rewrites the schedule table in README.md.
+"""
+
+import json
+import os
+import re
+import sys
+from datetime import datetime
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError
+
+REPO = "githubevents/open-source-friday"
+README_PATH = "README.md"
+START_MARKER = "<!-- SCHEDULE_START -->"
+END_MARKER = "<!-- SCHEDULE_END -->"
+
+# Map GitHub logins → display names for the hosting team
+HOST_NAMES = {
+    "AndreaGriffiths11": "Andrea Griffiths",
+    "LadyKerr": "Kedasha Kerr",
+    "KevinCrosby": "Kevin Crosby",
+}
+
+
+def gh_get(path: str, token: str) -> list | dict:
+    url = f"https://api.github.com{path}"
+    req = Request(url, headers={
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    })
+    with urlopen(req) as resp:
+        return json.loads(resp.read())
+
+
+def fetch_scheduled_issues(token: str) -> list:
+    issues = []
+    page = 1
+    while True:
+        batch = gh_get(
+            f"/repos/{REPO}/issues?labels=scheduled&state=open&per_page=100&page={page}",
+            token,
+        )
+        if not batch:
+            break
+        issues.extend(batch)
+        if len(batch) < 100:
+            break
+        page += 1
+    return issues
+
+
+def parse_field(body: str, label: str) -> str:
+    """Extract the value under a ### <label> heading in the issue body."""
+    pattern = rf"###\s+{re.escape(label)}\s*\n+(.+?)(?=\n###|\Z)"
+    match = re.search(pattern, body, re.DOTALL)
+    if not match:
+        return ""
+    return match.group(1).strip()
+
+
+def parse_date(raw: str) -> datetime | None:
+    """Try common date formats found in the issues."""
+    raw = raw.strip()
+    for fmt in ("%m-%d-%Y", "%m/%d/%Y", "%-m-%-d-%Y"):
+        try:
+            return datetime.strptime(raw, fmt)
+        except ValueError:
+            pass
+    # Try without leading zeros via regex
+    m = re.match(r"^(\d{1,2})[-/](\d{1,2})[-/](\d{4})$", raw)
+    if m:
+        month, day, year = int(m.group(1)), int(m.group(2)), int(m.group(3))
+        try:
+            return datetime(year, month, day)
+        except ValueError:
+            pass
+    return None
+
+
+def build_row(issue: dict) -> dict | None:
+    body = issue.get("body") or ""
+    number = issue["number"]
+    url = issue["html_url"]
+
+    guest_name = parse_field(body, "Name")
+    raw_date = parse_field(body, "Dates")
+    project = parse_field(body, "Project Name")
+
+    # Skip issues where the date is clearly TBD / not set
+    if not raw_date or raw_date.upper() in ("TBD", "_NO RESPONSE_", "NOT YET"):
+        print(f"  Skipping #{number}: date is '{raw_date}'")
+        return None
+
+    date_obj = parse_date(raw_date)
+    if not date_obj:
+        print(f"  Skipping #{number}: could not parse date '{raw_date}'")
+        return None
+
+    assignees = issue.get("assignees") or []
+    if assignees:
+        host = ", ".join(
+            HOST_NAMES.get(a["login"], a["login"]) for a in assignees
+        )
+    else:
+        host = "TBD"
+
+    return {
+        "date": date_obj,
+        "date_str": date_obj.strftime("%B %-d, %Y"),
+        "guest": guest_name or "TBD",
+        "project": project or "TBD",
+        "host": host,
+        "url": url,
+        "number": number,
+    }
+
+
+def build_table(rows: list) -> str:
+    today = datetime.now(tz=None).replace(hour=0, minute=0, second=0, microsecond=0)
+    upcoming = sorted(
+        [r for r in rows if r["date"] >= today],
+        key=lambda r: r["date"],
+    )
+
+    if not upcoming:
+        return "_No upcoming streams scheduled yet._\n"
+
+    lines = [
+        "| Date | Guest | Project | Host |",
+        "| ---- | ----- | ------- | ---- |",
+    ]
+    for r in upcoming:
+        lines.append(
+            f"| {r['date_str']} | [{r['guest']}]({r['url']}) | {r['project']} | {r['host']} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def update_readme(table_md: str) -> bool:
+    with open(README_PATH, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    if START_MARKER not in content or END_MARKER not in content:
+        print("ERROR: schedule markers not found in README.md")
+        sys.exit(1)
+
+    new_block = f"{START_MARKER}\n{table_md}{END_MARKER}"
+    updated = re.sub(
+        rf"{re.escape(START_MARKER)}.*?{re.escape(END_MARKER)}",
+        new_block,
+        content,
+        flags=re.DOTALL,
+    )
+
+    if updated == content:
+        print("README.md is already up to date.")
+        return False
+
+    with open(README_PATH, "w", encoding="utf-8") as f:
+        f.write(updated)
+    print("README.md updated.")
+    return True
+
+
+def main():
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("ERROR: GITHUB_TOKEN environment variable is not set.")
+        sys.exit(1)
+
+    print("Fetching scheduled issues…")
+    try:
+        issues = fetch_scheduled_issues(token)
+    except HTTPError as e:
+        print(f"ERROR: GitHub API request failed: {e}")
+        sys.exit(1)
+
+    print(f"Found {len(issues)} scheduled issue(s).")
+
+    rows = []
+    for issue in issues:
+        row = build_row(issue)
+        if row:
+            rows.append(row)
+
+    print(f"Parsed {len(rows)} issue(s) with valid dates.")
+    table_md = build_table(rows)
+    update_readme(table_md)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/update-schedule.yml
+++ b/.github/workflows/update-schedule.yml
@@ -1,0 +1,44 @@
+name: Update Schedule Table in README
+
+on:
+  issues:
+    types: [labeled, unlabeled, closed, reopened, edited, assigned, unassigned]
+  schedule:
+    - cron: "0 9 * * 1" # Every Monday at 9 AM UTC
+  workflow_dispatch:
+
+jobs:
+  update-schedule:
+    runs-on: ubuntu-latest
+    # Only run on issue events when the 'scheduled' label is involved,
+    # or when triggered by schedule / manually
+    if: >
+      github.event_name != 'issues' ||
+      github.event.label.name == 'scheduled' ||
+      contains(github.event.issue.labels.*.name, 'scheduled')
+
+    permissions:
+      contents: write
+      issues: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build schedule table and update README
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python .github/scripts/update_schedule.py
+
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git diff --quiet README.md || (
+            git add README.md &&
+            git commit -m "chore: auto-update upcoming schedule table in README" &&
+            git push
+          )

--- a/README.md
+++ b/README.md
@@ -10,4 +10,12 @@ Join [Andrea Griffiths](https://www.x.com/alacolombiadev/), [Kedasha Kerr](https
 
 Don't miss this chance to explore the world of Open Source every Friday. We're live on [Twitch](https://www.twitch.tv/github), and you can catch up on previous sessions on our [YouTube playlist](https://www.youtube.com/playlist?list=PL0lo9MOBetEFmtstItnKlhJJVmMghxc0P). Join the community and expand your Open Source knowledge!
 
+## Upcoming Streams 📅
 
+<!-- SCHEDULE_START -->
+| Date | Guest | Project | Host |
+| ---- | ----- | ------- | ---- |
+| April 17, 2026 | [Gunnar Morling](https://github.com/githubevents/open-source-friday/issues/205) | Hardwood | brunoborges |
+| April 24, 2026 | [Teja Kummarikuntla](https://github.com/githubevents/open-source-friday/issues/211) | Kong | TBD |
+| May 1, 2026 | [Jonny Burger](https://github.com/githubevents/open-source-friday/issues/210) | Remotion | Kedasha Kerr |
+<!-- SCHEDULE_END -->


### PR DESCRIPTION
…README

- Add .github/scripts/update_schedule.py: fetches all issues labelled 'scheduled', parses guest name, stream date, and project from the issue body, derives the host from issue assignees, and rewrites the table README.md.
- Add .github/workflows/update-schedule.yml: triggers on issue events involving the 'scheduled' label (label added/removed, issue closed, edited, assigned, etc.), on a Monday morning cron, and via workflow_dispatch.
- Update README.md: add '## Upcoming Streams' section with the markers and an initial run of the generated table.