### PR TITLE
Refresh host names in admin docs + tidy host checklist

### DIFF
--- a/.github/workflows/scheduled-notifications.yml
+++ b/.github/workflows/scheduled-notifications.yml
@@ -79,10 +79,8 @@ jobs:
               'This stream has been scheduled. Please complete the following tasks:',
               '',
               '- [ ] Create social card',
-              '- [ ] Create meetup link',
-              '- [ ] Create and schedule twitch stream (LinkedIn, Twitch, YouTube)',
-              '- [ ] Schedule social media post (Twitter)',
-              '- [ ] Send prep doc to guests',
+              '- [ ] Create and schedule stream in StreamYard (LinkedIn, Twitch, YouTube)',
+              '- [ ] Schedule social media post',
               '',
               'You can find the instructions in this [guide](https://github.com/githubevents/open-source-friday/blob/main/admin/guest-assets/Streaming-Guide.md).',
             ].join('\n');

--- a/admin/README.md
+++ b/admin/README.md
@@ -4,7 +4,7 @@ Ideal flow for actions:
 
 - send Open Source Friday Invite Template and booking link to potential guests
 - they complete the form with the date selected and submit the issue
-- the issue is automatically assigned to Andrea and Kevin with the label `pending`
+- the issue is automatically assigned to Andrea, Kevin, Marlene, and Gwen with the label `pending`
 - the issue triggers a workflow that creates a comment reminding the guest to book a time slot if t hey haven't already
 - we go in and add the `scheduled` label to the issue to confirm booking
 - At the approved label, the workflow triggers and creates a new comment in the issue reminding the hosts to create the event + assets

--- a/admin/approved-guest.md
+++ b/admin/approved-guest.md
@@ -2,7 +2,7 @@ Dear Guest,
 
 Thank you for agreeing to join us on Open Source Friday! We're excited to have you share your project with our community.
 
-Your session will be hosted by Andrea Griffiths and/or Kevin Crosby and will stream live on Twitch at 1 PM EST on your scheduled Friday. To get you set up:
+Your session will be hosted by one of the Open Source Friday team — Andrea Griffiths, Kevin Crosby, Marlene Mhangami, or Gwyneth Peña-Siguenza — and will stream live on Twitch at 1 PM ET on your scheduled Friday. To get you set up:
 
 1. Please select an upcoming Friday from our streaming calendar: [calendar link](https://gh.io/osf-booking)
 
@@ -16,4 +16,4 @@ Looking forward to having you on the show!
 
 With gratitude,
 
-Andrea and Kevin
+Andrea, Kevin, Marlene & Gwen

--- a/admin/cal-invite-copy.md
+++ b/admin/cal-invite-copy.md
@@ -12,4 +12,4 @@ Here is a recording guide for streaming remotely.
 
 
 Chat soon!
-Andrea & Kevin
+Andrea, Kevin, Marlene & Gwen

--- a/admin/guest-invite.md
+++ b/admin/guest-invite.md
@@ -17,4 +17,4 @@ Feel free to ping us if you have any questions or need more details on anything!
 
 Warm regards,
 
-Andrea and Kevin
+Andrea, Kevin, Marlene & Gwen


### PR DESCRIPTION
Follow-up to #229.

PR #229 added Marlene and Gwen as hosts across the README, CONTRIBUTING, the guest invite template, and the auto-posted guest  but missed the `admin/` folder. Those docs are the copy that hosts actually paste into LinkedIn DMs and calendar invites, so guests are still seeing the two-host signature.welcome 

### Admin doc refresh
- `admin/README. assignees line now reflects all four hostsmd` 
- `admin/approved-guest. opening line + signoffmd` 
- `admin/cal-invite-copy. signoffmd` 
- `admin/guest-invite. signoffmd` 

### Host checklist tidy (`scheduled-notifications.yml`)
Surfaced during the onboarding walkthrough this morning:

- **Removed "Send prep doc to  `welcome.yml` already posts the Streaming-Guide link to the guest at the `scheduled` label, so this task is redundant.guests"** 
- **Removed "Create meetup  meetup events are on hold pending a decision about reviving the program.link"** 
 "Create and schedule stream in StreamYard"** to match how we actually talk about it.
- **Dropped "(Twitter)" qualifier** from the social post task since we schedule across LinkedIn + Twitter via Sprout.

No workflow logic  just text inside the host comment body.