### PR TITLE
Clarify approval workflow in guest invite templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/osf-guest-invite.yml
+++ b/.github/ISSUE_TEMPLATE/osf-guest-invite.yml
@@ -15,6 +15,8 @@ body:
         ## Open Source Friday Guest Invite Form
         #### :sparkles: Please fill out the following information to be invited to Open Source Friday. The stream occurs weekly at 1pm EST on the [GitHub Twitch Channel](https://www.twitch.tv/github). :sparkles:
 
+        **You don't need a stream date to submit.** We review every request, and once your project is approved we'll apply the `approved` label and a bot will comment on this issue with a calendar link so you can book your slot. If you already have a date in mind, add it below — otherwise just check "Not yet" and we'll take it from there.
+
   - type: input
     id: name
     attributes:
@@ -54,7 +56,7 @@ body:
     id: stream_date
     attributes:
       label: Stream Date
-      description: Did you schedule a date for your stream?
+      description: "Already picked a date from https://gh.io/osf-booking? Let us know. If not, choose \"Not yet\" — we'll send you the booking link once your request is approved."
       options:
         - label: "Yes"
         - label: "Not yet"
@@ -63,7 +65,7 @@ body:
     id: dates_1
     attributes:
       label: Dates
-      description: what date did you schedule for Open Source Friday stream?
+      description: "Optional — only fill this in if you've already booked a slot. Format: MM-DD-YYYY."
       placeholder: MM-DD-YYYY
 
   - type: input

--- a/.github/ISSUE_TEMPLATE/viernes.yml
+++ b/.github/ISSUE_TEMPLATE/viernes.yml
@@ -13,6 +13,8 @@ body:
       value: |
         ## Formulario de Invitación para Invitados de Open Source Friday
         #### :sparkles: Por favor, complete la siguiente información para ser invitado a Open Source Viernes. La fecha de la transmisión ser confirmada al aprovar el invitado :sparkles:
+
+        **No necesitas una fecha para enviar tu solicitud.** Revisamos cada propuesta y, cuando tu proyecto sea aprobado, aplicaremos la etiqueta `approved` y un bot dejará un comentario en este issue con el enlace al calendario para que reserves tu transmisión. Si ya tienes una fecha en mente, inclúyela abajo — si no, marca "Aún no" y nosotros nos encargamos del resto.
   - type: input
     id: nombre
     attributes:
@@ -47,7 +49,7 @@ body:
     id: fecha_transmision
     attributes:
       label: Fecha de Transmisión
-      description: ¿Has programado una fecha para tu transmisión?
+      description: "¿Ya escogiste una fecha en https://gh.io/osf-booking? Cuéntanos. Si no, marca \"Aún no\" — te enviaremos el enlace para reservar cuando tu solicitud sea aprobada."
       options:
         - label: "Sí"
         - label: "Aún no"


### PR DESCRIPTION
Closes part of the feedback in #231.

@jcubic raised a fair point: the form asks for a stream date as if it's required, but at the proposal stage guests have no way to know one. The current workflow is:

1. Guest opens an issue (no date needed)
2. Maintainer reviews and applies the `approved` label
3. The [`notify-approved-guests` workflow](https://github.com/githubevents/open-source-friday/blob/main/.github/workflows/notify-approved-guests.yml) auto-comments with the `gh.io/osf-booking` calendar link
4. Guest picks a slot and replies with the date

but none of that was documented in the form itself. This PR adds a short note at the top of both the English and Spanish templates explaining the flow, and reworks the Stream Date / Dates field descriptions so they read as optional rather than required.

### Changes

- `osf-guest-invite. adds intro note, rewrites Stream Date + Dates descriptionsyml` 
- `viernes. same intro note + Stream Date description in Spanishyml` 

No schema changes, no required-field changes, no workflow changes.