### PR TITLE
Fix guest promo pipeline: trigger on `scheduled`, hide unknown host

### DIFF
--- a/.github/scripts/extract_guest_metadata.py
+++ b/.github/scripts/extract_guest_metadata.py
@@ -89,10 +89,16 @@ def main() -> None:
     stream_date = parse_date(raw_date) if raw_date else "Date TBD"
 
     assignees = issue.get("assignees") or []
-    host_name = "TBD"
-    if assignees:
+    # Every new issue auto-assigns all four hosts via the issue template.
+    # The actual host is decided in a team meeting and only known once the
+    # other assignees have been removed. Treat host as TBD until exactly one
+    # assignee remains — the video template hides the "with {host}" line when
+    # host_name == "TBD".
+    if len(assignees) == 1:
         login = assignees[0]["login"]
         host_name = HOST_NAMES.get(login, login)
+    else:
+        host_name = "TBD"
 
     # Truncate bio for video overlay
     if bio and len(bio) > 280:

--- a/.github/workflows/guest-promo-pipeline.yml
+++ b/.github/workflows/guest-promo-pipeline.yml
@@ -12,8 +12,12 @@ on:
 
 jobs:
   generate-promo:
-    # Run when labeled "approved", or on manual dispatch
-    if: github.event.label.name == 'approved' || github.event_name == 'workflow_dispatch'
+    # Trigger only once the stream is actually on the calendar (the `scheduled`
+    # label is applied after the date is locked in), or on manual dispatch.
+    # We deliberately do not trigger on the `approved` label because at that
+    # point the guest has only just been invited to pick a slot — there is no
+    # date yet, so the promo would render with placeholder text.
+    if: github.event.label.name == 'scheduled' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
Two related bugs in the [guest promo pipeline](https://github.com/githubevents/open-source-friday/blob/main/.github/workflows/guest-promo-pipeline). both visible in [run #26719009733](https://github.com/githubevents/open-source-friday/actions/runs/26719009733/workflow), which rendered "with Kevin Crosby" on a freshly-approved issue that has no date and no decided host yet.yml) 

## What was wrong

### 1. Promo fires on `approved`, but the date isn't known yet

The pipeline currently triggers when the `approved` label is applied. But the [`notify-approved-guests` workflow](https://github.com/githubevents/open-source-friday/blob/main/.github/workflows/notify-approved-guests.yml) makes it explicit that `approved` means *"please go pick a slot from gh.io/osf-booking."* No date is committed at that point, so the promo renders with placeholder text where the date should be.

The right trigger is ` that label is applied *after* the date is locked in.scheduled` 

### 2. Host is picked from auto-assignees

`extract_guest_metadata.py` does `host_name = HOST_NAMES[assignees[0]["login"]]`. But the issue template auto-assigns **all four** hosts to every new  the actual host is decided in a team meeting and only known once the other three assignees are removed. So the promo always reads "with Kevin Crosby" (alphabetically first), regardless of who will actually host.request 

## Fix

- `guest-promo-pipeline.yml`: change the `if` from `label.name == 'approved'` to `label.name == 'scheduled'`, with a comment explaining why.
- `extract_guest_metadata.py`: only treat a single remaining assignee as the host. If `len(assignees) != 1`, set `host_name = "TBD"`. The Remotion template already hides the `with {host_name}` line when host is TBD ([`GuestPromo.tsx#L204`](https://github.com/githubevents/open-source-friday/blob/main/video/src/GuestPromo/GuestPromo.tsx#L204)), so the rendered video just shows the date and  clean.project 

`workflow_dispatch` is unchanged, so once the host is decided we can manually re-render with the right name baked in.

