### PR TITLE
Add OSF producer canvas extension

### DIFF
--- a/.github/extensions/osf-producer-canvas/extension.mjs
+++ b/.github/extensions/osf-producer-canvas/extension.mjs
@@ -1,0 +1,188 @@
+import { createServer } from "node:http";
+import { CanvasError, createCanvas, joinSession } from "@github/copilot-sdk/extension";
+import { buildProducerState, normalizeOpenInput, recordDecision } from "./producer-data.mjs";
+import { renderHtml } from "./renderer.mjs";
+
+const servers = new Map();
+let workspacePath = process.cwd();
+
+function getWorkspacePath() {
+    return workspacePath || process.cwd();
+}
+
+function writeJson(res, statusCode, payload) {
+    res.writeHead(statusCode, {
+        "Content-Type": "application/json; charset=utf-8",
+        "Cache-Control": "no-store",
+    });
+    res.end(JSON.stringify(payload));
+}
+
+async function readJson(req) {
+    const chunks = [];
+    let size = 0;
+
+    for await (const chunk of req) {
+        size += chunk.length;
+        if (size > 64 * 1024) {
+            throw new Error("Request body is too large.");
+        }
+        chunks.push(chunk);
+    }
+
+    const body = Buffer.concat(chunks).toString("utf8").trim();
+    return body ? JSON.parse(body) : {};
+}
+
+async function handleRequest(req, res, entry) {
+    const url = new URL(req.url || "/", "http://127.0.0.1");
+
+    if (req.method === "GET" && url.pathname === "/") {
+        res.writeHead(200, {
+            "Content-Type": "text/html; charset=utf-8",
+            "Cache-Control": "no-store",
+        });
+        res.end(renderHtml());
+        return;
+    }
+
+    if (req.method === "GET" && url.pathname === "/state") {
+        const state = await buildProducerState(entry.config, getWorkspacePath());
+        writeJson(res, 200, state);
+        return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/decision") {
+        const input = await readJson(req);
+        const decision = await recordDecision(entry.config.repository, input);
+        writeJson(res, 200, decision);
+        return;
+    }
+
+    writeJson(res, 404, { error: "Not found." });
+}
+
+async function startServer(entry) {
+    const server = createServer((req, res) => {
+        handleRequest(req, res, entry).catch((error) => {
+            writeJson(res, 500, { error: error.message });
+        });
+    });
+
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+
+    entry.server = server;
+    entry.url = `http://127.0.0.1:${port}/`;
+}
+
+const producerCanvas = createCanvas({
+    id: "osf-producer",
+    displayName: "Open Source Friday Producer",
+    description: "Reviews Open Source Friday guest requests and recommends the next producer action.",
+    inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+            repository: {
+                type: "string",
+                description: "GitHub repository in owner/name form.",
+                default: "githubevents/open-source-friday",
+            },
+            dashboardUrl: {
+                type: "string",
+                description: "Existing dashboard URL for source data review.",
+                default: "https://dash-osf.netlify.app/",
+            },
+            weeks: {
+                type: "integer",
+                minimum: 4,
+                maximum: 26,
+                description: "Number of upcoming Fridays to scan for schedule gaps.",
+                default: 12,
+            },
+        },
+    },
+    actions: [
+        {
+            name: "get_snapshot",
+            description: "Returns the current producer snapshot, including pending requests, schedule gaps, automation output, and decisions.",
+            inputSchema: {
+                type: "object",
+                additionalProperties: false,
+                properties: {
+                    repository: { type: "string" },
+                    dashboardUrl: { type: "string" },
+                    weeks: { type: "integer", minimum: 4, maximum: 26 },
+                },
+            },
+            handler: async (ctx) => {
+                const config = normalizeOpenInput(ctx.input);
+                try {
+                    return await buildProducerState(config, getWorkspacePath());
+                } catch (error) {
+                    throw new CanvasError("producer_snapshot_failed", error.message);
+                }
+            },
+        },
+        {
+            name: "record_decision",
+            description: "Records a producer decision for one Open Source Friday issue in local extension storage.",
+            inputSchema: {
+                type: "object",
+                additionalProperties: false,
+                required: ["issueNumber", "decision"],
+                properties: {
+                    repository: { type: "string" },
+                    issueNumber: { type: "integer", minimum: 1 },
+                    decision: {
+                        type: "string",
+                        enum: ["approve", "needs_info", "assign_host", "confirm_date", "schedule", "defer", "done"],
+                    },
+                    note: { type: "string" },
+                },
+            },
+            handler: async (ctx) => {
+                try {
+                    const config = normalizeOpenInput(ctx.input);
+                    return await recordDecision(config.repository, ctx.input);
+                } catch (error) {
+                    throw new CanvasError("producer_decision_failed", error.message);
+                }
+            },
+        },
+    ],
+    open: async (ctx) => {
+        const config = normalizeOpenInput(ctx.input);
+        let entry = servers.get(ctx.instanceId);
+
+        if (!entry) {
+            entry = { config, server: null, url: "" };
+            await startServer(entry);
+            servers.set(ctx.instanceId, entry);
+        }
+
+        entry.config = config;
+        return {
+            title: "Open Source Friday Producer",
+            status: "Producer decisions",
+            url: entry.url,
+        };
+    },
+    onClose: async (ctx) => {
+        const entry = servers.get(ctx.instanceId);
+        if (!entry) {
+            return;
+        }
+
+        servers.delete(ctx.instanceId);
+        await new Promise((resolve) => entry.server.close(() => resolve()));
+    },
+});
+
+const session = await joinSession({
+    canvases: [producerCanvas],
+});
+
+workspacePath = session.workspacePath || process.cwd();

--- a/.github/extensions/osf-producer-canvas/producer-data.mjs
+++ b/.github/extensions/osf-producer-canvas/producer-data.mjs
@@ -1,0 +1,625 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Derive the repo root from this file's location:
+// producer-data.mjs → osf-producer-canvas → extensions → .github → repo root
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+
+const DEFAULT_REPOSITORY = "githubevents/open-source-friday";
+const DEFAULT_DASHBOARD_URL = "https://dash-osf.netlify.app/";
+const DEFAULT_WEEKS = 12;
+const SCHEDULE_START = "<!-- SCHEDULE_START -->";
+const SCHEDULE_END = "<!-- SCHEDULE_END -->";
+
+const HOST_NAMES = new Map([
+    ["AndreaGriffiths11", "Andrea Griffiths"],
+    ["KevinCrosby", "Kevin Crosby"],
+    ["marlenezw", "Marlene Mhangami"],
+    ["madebygps", "Gwyneth Pena-Siguenza"],
+]);
+
+const BLANK_VALUES = new Set(["", "_NO RESPONSE_", "TBD", "NOT YET", "N/A", "NONE", "NO"]);
+const DECISIONS = new Set(["approve", "needs_info", "assign_host", "confirm_date", "schedule", "defer", "done"]);
+
+export function normalizeOpenInput(input = {}) {
+    return {
+        repository: typeof input.repository === "string" && input.repository ? input.repository : DEFAULT_REPOSITORY,
+        dashboardUrl: typeof input.dashboardUrl === "string" && input.dashboardUrl ? input.dashboardUrl : DEFAULT_DASHBOARD_URL,
+        weeks: Number.isInteger(input.weeks) ? input.weeks : DEFAULT_WEEKS,
+    };
+}
+
+export async function buildProducerState(config, workspacePath) {
+    const [issueResult, readmeSchedule, savedDecisions] = await Promise.all([
+        fetchOpenIssuesSafely(config.repository),
+        readScheduleFromReadme(workspacePath),
+        readSavedDecisions(config.repository),
+    ]);
+
+    const issues = issueResult.issues;
+    const issueModels = issues.map(parseIssue);
+    const pendingRequests = issueModels.filter((issue) => issue.isPending);
+    const pendingWithChecks = await addRepositoryChecks(pendingRequests);
+    const reviewedPending = pendingWithChecks.map(addReadiness);
+    const readyToApprove = reviewedPending.filter((issue) => issue.readiness.ready);
+    const needsMoreInfo = reviewedPending.filter((issue) => !issue.readiness.ready);
+    const scheduledIssues = issueModels.filter((issue) => issue.isScheduled);
+    const approvedGuests = issueModels.filter((issue) => issue.isApproved);
+    const approvedNeedsScheduling = approvedGuests.filter(needsDateHostOrScheduledLabel);
+    const schedule = buildSchedule(scheduledIssues, readmeSchedule.rows, config.weeks);
+    const producerDecisions = buildProducerDecisions({
+        readyToApprove,
+        needsMoreInfo,
+        approvedNeedsScheduling,
+        schedule,
+    });
+
+    return {
+        generatedAt: new Date().toISOString(),
+        repository: config.repository,
+        dashboardUrl: config.dashboardUrl,
+        summary: "The dashboard shows what exists; this canvas helps decide what happens next.",
+        warnings: issueResult.warnings,
+        counts: {
+            openIssues: issueModels.length,
+            pendingRequests: pendingRequests.length,
+            readyToApprove: readyToApprove.length,
+            needsMoreInfo: needsMoreInfo.length,
+            approvedNeedsScheduling: approvedNeedsScheduling.length,
+            scheduleGaps: schedule.emptyFridays.length,
+            overbookedDates: schedule.overbookedDates.length,
+        },
+        pendingRequests: reviewedPending,
+        readyToApprove,
+        needsMoreInfo,
+        approvedNeedsScheduling,
+        schedule,
+        automationOutput: buildAutomationOutput(readmeSchedule, approvedGuests, scheduledIssues),
+        producerDecisions,
+        savedDecisions,
+    };
+}
+
+export async function recordDecision(repository, input = {}) {
+    const issueNumber = Number(input.issueNumber);
+    const decision = String(input.decision || "");
+    const note = typeof input.note === "string" ? input.note.trim() : "";
+
+    if (!Number.isInteger(issueNumber) || issueNumber < 1) {
+        throw new Error("issueNumber must be a positive integer.");
+    }
+
+    if (!DECISIONS.has(decision)) {
+        throw new Error("decision must be one of the supported producer decisions.");
+    }
+
+    const decisions = await readSavedDecisions(repository);
+    decisions[String(issueNumber)] = {
+        issueNumber,
+        decision,
+        note,
+        updatedAt: new Date().toISOString(),
+    };
+
+    await writeSavedDecisions(repository, decisions);
+    return decisions[String(issueNumber)];
+}
+
+async function fetchOpenIssues(repository) {
+    const issues = [];
+
+    for (let page = 1; page <= 10; page += 1) {
+        const url = `https://api.github.com/repos/${repository}/issues?state=open&per_page=100&page=${page}`;
+        const batch = await fetchGitHubJson(url);
+        const issueBatch = batch.filter((issue) => !issue.pull_request);
+        issues.push(...issueBatch);
+
+        if (batch.length < 100) {
+            break;
+        }
+    }
+
+    return issues;
+}
+
+async function fetchOpenIssuesSafely(repository) {
+    try {
+        return {
+            issues: await fetchOpenIssues(repository),
+            warnings: [],
+        };
+    } catch (error) {
+        return {
+            issues: [],
+            warnings: [`Could not load GitHub issues: ${error.message}`],
+        };
+    }
+}
+
+async function fetchGitHubJson(url) {
+    const headers = {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "osf-producer-canvas",
+    };
+    const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+
+    if (token) {
+        headers.Authorization = `Bearer ${token}`;
+    }
+
+    const response = await fetch(url, { headers });
+    if (!response.ok) {
+        const remaining = response.headers.get("x-ratelimit-remaining");
+        if ((response.status === 403 || response.status === 429) && remaining === "0") {
+            throw new Error("GitHub rate limit reached. Set GITHUB_TOKEN or GH_TOKEN for authenticated requests.");
+        }
+
+        const detail = await response.text();
+        throw new Error(`GitHub request failed with ${response.status}: ${detail.slice(0, 240)}`);
+    }
+
+    return response.json();
+}
+
+function parseIssue(issue) {
+    const labels = issue.labels.map((label) => label.name);
+    const labelSet = new Set(labels);
+    const body = issue.body || "";
+    const date = parseIssueDate(parseField(body, "Dates") || parseDateFromTitle(issue.title || ""));
+    const host = parseHost(issue.assignees || []);
+
+    return {
+        number: issue.number,
+        title: issue.title || "",
+        url: issue.html_url,
+        labels,
+        guestName: parseField(body, "Name"),
+        githubHandle: parseField(body, "GitHub Handle"),
+        about: parseField(body, "Tell us about yourself"),
+        projectName: parseField(body, "Project Name"),
+        projectRepoUrl: parseField(body, "Project Repo Link"),
+        additionalInfo: parseField(body, "Additional Information"),
+        dateText: parseField(body, "Dates"),
+        dateKey: date ? formatDateKey(date) : "",
+        dateDisplay: date ? formatDisplayDate(date) : "",
+        assignees: issue.assignees.map((assignee) => assignee.login),
+        hostName: host.name,
+        hostReason: host.reason,
+        isPending: labelSet.has("pending") && !labelSet.has("approved") && !labelSet.has("scheduled"),
+        isApproved: labelSet.has("approved"),
+        isScheduled: labelSet.has("scheduled"),
+        createdAt: issue.created_at,
+        updatedAt: issue.updated_at,
+        daysOld: Math.floor((Date.now() - new Date(issue.created_at).getTime()) / 86400000),
+    };
+}
+
+function parseField(body, field) {
+    const pattern = new RegExp(`###\\s+${escapeRegExp(field)}\\s*\\n+([\\s\\S]*?)(?=\\n###|$)`);
+    const match = body.match(pattern);
+
+    if (!match) {
+        return "";
+    }
+
+    return cleanValue(match[1]);
+}
+
+function cleanValue(value) {
+    const text = value
+        .replace(/<!--[\s\S]*?-->/g, "")
+        .replace(/^- \[[ xX]\]\s*/gm, "")
+        .trim();
+
+    if (BLANK_VALUES.has(text.toUpperCase())) {
+        return "";
+    }
+
+    return text;
+}
+
+function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function parseHost(assignees) {
+    if (assignees.length === 1) {
+        const login = assignees[0].login;
+        return {
+            name: HOST_NAMES.get(login) || login,
+            reason: "",
+        };
+    }
+
+    if (assignees.length === 0) {
+        return { name: "", reason: "No host is assigned." };
+    }
+
+    return {
+        name: "",
+        reason: "More than one assignee remains, so the host is still TBD.",
+    };
+}
+
+function parseDateFromTitle(title) {
+    const numeric = title.match(/(\d{1,2}[-/]\d{1,2}[-/]\d{2,4})/);
+    if (numeric) {
+        return numeric[1];
+    }
+
+    const month = title.match(/(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{1,2},?\s+\d{4}/);
+    return month ? month[0] : "";
+}
+
+function parseIssueDate(rawDate) {
+    const value = cleanValue(rawDate || "");
+    if (!value) {
+        return null;
+    }
+
+    const numeric = value.match(/^(\d{1,2})[-/](\d{1,2})[-/](\d{2}|\d{4})$/);
+    if (numeric) {
+        const year = numeric[3].length === 2 ? `20${numeric[3]}` : numeric[3];
+        return new Date(Date.UTC(Number(year), Number(numeric[1]) - 1, Number(numeric[2])));
+    }
+
+    const parsed = new Date(`${value} UTC`);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function formatDateKey(date) {
+    return date.toISOString().slice(0, 10);
+}
+
+function formatDisplayDate(date) {
+    return date.toLocaleDateString("en-US", {
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+        timeZone: "UTC",
+    });
+}
+
+async function addRepositoryChecks(issues) {
+    const checkedIssues = [];
+
+    for (const issue of issues) {
+        checkedIssues.push({
+            ...issue,
+            repoCheck: await loadRepositoryCheck(issue.projectRepoUrl),
+        });
+    }
+
+    return checkedIssues;
+}
+
+async function loadRepositoryCheck(projectRepoUrl) {
+    const parsed = parseGitHubRepository(projectRepoUrl);
+    if (!parsed) {
+        return {
+            passed: false,
+            repository: "",
+            checks: [],
+            reasons: ["Project repo link needs a GitHub owner/repo URL."],
+        };
+    }
+
+    try {
+        const repo = await fetchGitHubJson(`https://api.github.com/repos/${parsed.owner}/${parsed.repo}`);
+        const tree = await fetchGitHubJson(`https://api.github.com/repos/${parsed.owner}/${parsed.repo}/git/trees/${repo.default_branch}?recursive=1`);
+        return buildRepositoryCheck(repo, tree.tree || []);
+    } catch (error) {
+        return {
+            passed: false,
+            repository: `${parsed.owner}/${parsed.repo}`,
+            checks: [],
+            reasons: [`Could not load repository metadata: ${error.message}`],
+        };
+    }
+}
+
+function parseGitHubRepository(value) {
+    const text = value.trim().replace(/\.git$/i, "");
+    const match = text.match(/github\.com[:/]+([^/\s]+)\/([^/\s#?]+)/i) || text.match(/^([^/\s]+)\/([^/\s#?]+)$/);
+
+    if (!match) {
+        return null;
+    }
+
+    return {
+        owner: match[1],
+        repo: match[2],
+    };
+}
+
+function buildRepositoryCheck(repo, tree) {
+    const paths = new Set(tree.map((item) => item.path.toLowerCase()));
+    const checks = [
+        {
+            label: "100+ stars",
+            passed: repo.stargazers_count >= 100,
+            detail: `${repo.stargazers_count} stars`,
+        },
+        {
+            label: "License",
+            passed: Boolean(repo.license) || hasAnyPath(paths, ["license", "license.md", "copying"]),
+            detail: repo.license ? repo.license.name : "No license detected",
+        },
+        {
+            label: "Code of conduct",
+            passed: hasAnyPath(paths, ["code_of_conduct.md", ".github/code_of_conduct.md", "docs/code_of_conduct.md"]),
+            detail: "Required by OSF criteria",
+        },
+        {
+            label: "Contributing guide",
+            passed: hasAnyPath(paths, ["contributing.md", ".github/contributing.md", "docs/contributing.md"]),
+            detail: "Required by OSF criteria",
+        },
+    ];
+    const reasons = checks.filter((check) => !check.passed).map((check) => `${check.label}: ${check.detail}`);
+
+    return {
+        passed: reasons.length === 0,
+        repository: repo.full_name,
+        url: repo.html_url,
+        checks,
+        reasons,
+    };
+}
+
+function hasAnyPath(paths, candidates) {
+    return candidates.some((candidate) => paths.has(candidate));
+}
+
+function addReadiness(issue) {
+    const missing = [];
+
+    if (!issue.guestName) {
+        missing.push("Guest name is missing.");
+    }
+    if (!issue.githubHandle) {
+        missing.push("GitHub handle is missing.");
+    }
+    if (!issue.about) {
+        missing.push("Guest background is missing.");
+    }
+    if (!issue.projectName) {
+        missing.push("Project name is missing.");
+    }
+    if (!issue.projectRepoUrl) {
+        missing.push("Project repo link is missing.");
+    }
+
+    const reasons = [...missing, ...issue.repoCheck.reasons];
+
+    return {
+        ...issue,
+        readiness: {
+            ready: reasons.length === 0,
+            reasons,
+        },
+    };
+}
+
+function needsDateHostOrScheduledLabel(issue) {
+    if (!issue.dateKey) {
+        return true;
+    }
+    if (!issue.hostName) {
+        return true;
+    }
+    return !issue.isScheduled;
+}
+
+function buildSchedule(scheduledIssues, readmeRows, weeks) {
+    const byDate = new Map();
+
+    for (const issue of scheduledIssues) {
+        if (!issue.dateKey) {
+            continue;
+        }
+        const issues = byDate.get(issue.dateKey) || [];
+        issues.push(issue);
+        byDate.set(issue.dateKey, issues);
+    }
+
+    const fridays = getUpcomingFridays(weeks);
+    const emptyFridays = fridays.filter((friday) => !byDate.has(friday.dateKey));
+    const overbookedDates = [...byDate.entries()]
+        .filter(([, issues]) => issues.length > 1)
+        .map(([dateKey, issues]) => ({
+            dateKey,
+            dateDisplay: issues[0].dateDisplay || dateKey,
+            issues,
+        }));
+
+    return {
+        weeks,
+        readmeRows,
+        scheduledIssues,
+        emptyFridays,
+        overbookedDates,
+    };
+}
+
+function getUpcomingFridays(weeks) {
+    const today = new Date();
+    const cursor = new Date(Date.UTC(today.getFullYear(), today.getMonth(), today.getDate()));
+    const daysUntilFriday = (5 - cursor.getUTCDay() + 7) % 7;
+    cursor.setUTCDate(cursor.getUTCDate() + daysUntilFriday);
+
+    return Array.from({ length: weeks }, (_, index) => {
+        const date = new Date(cursor);
+        date.setUTCDate(cursor.getUTCDate() + index * 7);
+        return {
+            dateKey: formatDateKey(date),
+            dateDisplay: formatDisplayDate(date),
+        };
+    });
+}
+
+async function readScheduleFromReadme(_workspacePath) {
+    const readmePath = path.join(REPO_ROOT, "README.md");
+
+    try {
+        const content = await readFile(readmePath, "utf8");
+        return {
+            rows: parseReadmeRows(content),
+            warning: "",
+        };
+    } catch (error) {
+        return {
+            rows: [],
+            warning: `Could not read README schedule: ${error.message}`,
+        };
+    }
+}
+
+function parseReadmeRows(content) {
+    const start = content.indexOf(SCHEDULE_START);
+    const end = content.indexOf(SCHEDULE_END);
+
+    if (start === -1 || end === -1 || end <= start) {
+        return [];
+    }
+
+    const block = content.slice(start + SCHEDULE_START.length, end);
+    return block
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.startsWith("|") && !line.includes("----") && !line.includes("Date | Guest"))
+        .map(parseReadmeRow)
+        .filter(Boolean);
+}
+
+function parseReadmeRow(line) {
+    const cells = line.split("|").map((cell) => cell.trim());
+    if (cells[0] === "") {
+        cells.shift();
+    }
+    if (cells[cells.length - 1] === "") {
+        cells.pop();
+    }
+
+    if (cells.length < 4) {
+        return null;
+    }
+
+    const link = cells[1].match(/\[([^\]]+)\]\(([^)]+)\)/);
+    return {
+        date: cells[0],
+        guest: link ? link[1] : cells[1],
+        url: link ? link[2] : "",
+        project: cells[2],
+        host: cells[3],
+    };
+}
+
+function buildAutomationOutput(readmeSchedule, approvedGuests, scheduledIssues) {
+    const scheduledWithoutHost = scheduledIssues.filter((issue) => !issue.hostName).length;
+    const approvedAwaitingSchedule = approvedGuests.filter((issue) => !issue.isScheduled).length;
+
+    return [
+        {
+            name: "Approval notification",
+            trigger: "Adding the approved label",
+            output: "Comments with the booking link so the guest can pick a Friday.",
+            current: `${approvedAwaitingSchedule} approved open issue(s) still need scheduling.`,
+        },
+        {
+            name: "Schedule table update",
+            trigger: "scheduled label, issue edit, assign, unassign, Monday cron, or manual run",
+            output: "Rebuilds the README upcoming streams table from scheduled issues.",
+            current: `${readmeSchedule.rows.length} README schedule row(s) found.`,
+            warning: readmeSchedule.warning,
+        },
+        {
+            name: "Guest promo metadata",
+            trigger: "Guest promo pipeline for a scheduled issue",
+            output: "Writes guest-promo.json. Host stays TBD until exactly one assignee remains.",
+            current: `${scheduledWithoutHost} scheduled issue(s) still need one clear host.`,
+        },
+    ];
+}
+
+function buildProducerDecisions(input) {
+    const decisions = [];
+
+    for (const issue of input.readyToApprove.slice(0, 8)) {
+        decisions.push(decisionFromIssue("Approve", issue, "approve", "Apply the approved label. Automation will send the booking link."));
+    }
+
+    for (const issue of input.needsMoreInfo.slice(0, 8)) {
+        decisions.push(decisionFromIssue("Request info", issue, "needs_info", issue.readiness.reasons[0]));
+    }
+
+    for (const issue of input.approvedNeedsScheduling.slice(0, 8)) {
+        const action = issue.dateKey ? "Assign one host and add scheduled if needed." : "Ask the guest to pick a date from the booking calendar.";
+        const decision = issue.dateKey ? "assign_host" : "confirm_date";
+        decisions.push(decisionFromIssue("Schedule", issue, decision, action));
+    }
+
+    for (const gap of input.schedule.emptyFridays.slice(0, 6)) {
+        decisions.push({
+            category: "Fill gap",
+            issueNumber: null,
+            title: gap.dateDisplay,
+            action: "Pick an approved guest or source a new guest for this Friday.",
+            decision: "schedule",
+            url: "",
+        });
+    }
+
+    for (const date of input.schedule.overbookedDates) {
+        decisions.push({
+            category: "Resolve date collision",
+            issueNumber: null,
+            title: date.dateDisplay,
+            action: `${date.issues.length} scheduled issues share this date. Move one guest or confirm a double booking.`,
+            decision: "schedule",
+            url: "",
+        });
+    }
+
+    return decisions;
+}
+
+function decisionFromIssue(category, issue, decision, action) {
+    return {
+        category,
+        issueNumber: issue.number,
+        title: issue.projectName || issue.title,
+        guestName: issue.guestName,
+        action,
+        decision,
+        url: issue.url,
+    };
+}
+
+async function readSavedDecisions(repository) {
+    const filePath = decisionFilePath(repository);
+
+    try {
+        const content = await readFile(filePath, "utf8");
+        return JSON.parse(content);
+    } catch (error) {
+        if (error.code === "ENOENT") {
+            return {};
+        }
+        throw error;
+    }
+}
+
+async function writeSavedDecisions(repository, decisions) {
+    const filePath = decisionFilePath(repository);
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, `${JSON.stringify(decisions, null, 2)}\n`, "utf8");
+}
+
+function decisionFilePath(repository) {
+    const copilotHome = process.env.COPILOT_HOME || path.join(os.homedir(), ".copilot");
+    const safeName = repository.replace(/[^a-zA-Z0-9_.-]+/g, "-");
+    return path.join(copilotHome, "extensions", "osf-producer-canvas", "artifacts", `${safeName}-decisions.json`);
+}

--- a/.github/extensions/osf-producer-canvas/renderer.mjs
+++ b/.github/extensions/osf-producer-canvas/renderer.mjs
@@ -1,0 +1,588 @@
+export function renderHtml() {
+    return `<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Open Source Friday Producer</title>
+    <style>
+        :root {
+            color-scheme: light dark;
+        }
+
+        body {
+            margin: 0;
+            background: var(--background-color-default, #ffffff);
+            color: var(--text-color-default, #1f2328);
+            font-family: var(--font-sans, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+            font-size: var(--text-body-medium, 14px);
+            line-height: var(--leading-body-medium, 20px);
+        }
+
+        a {
+            color: var(--true-color-blue, #0969da);
+        }
+
+        button,
+        select,
+        textarea {
+            font: inherit;
+        }
+
+        .shell {
+            padding: 24px;
+            max-width: 1280px;
+            margin: 0 auto;
+        }
+
+        .topbar {
+            display: flex;
+            align-items: flex-start;
+            justify-content: space-between;
+            gap: 16px;
+            margin-bottom: 20px;
+        }
+
+        h1,
+        h2,
+        h3 {
+            margin: 0;
+            font-weight: var(--font-weight-semibold, 600);
+        }
+
+        h1 {
+            font-size: var(--text-title-large, 26px);
+            line-height: var(--leading-title-large, 32px);
+        }
+
+        h2 {
+            font-size: var(--text-title-medium, 20px);
+            line-height: var(--leading-title-medium, 26px);
+        }
+
+        h3 {
+            font-size: var(--text-body-large, 16px);
+            line-height: var(--leading-body-large, 22px);
+        }
+
+        .muted {
+            color: var(--text-color-muted, #656d76);
+        }
+
+        .button {
+            border: 1px solid var(--border-color-default, #d0d7de);
+            border-radius: 8px;
+            background: var(--background-color-default, #ffffff);
+            color: var(--text-color-default, #1f2328);
+            padding: 8px 12px;
+            cursor: pointer;
+            text-decoration: none;
+        }
+
+        .button.primary {
+            background: var(--true-color-blue, #0969da);
+            border-color: var(--true-color-blue, #0969da);
+            color: var(--color-white, #ffffff);
+        }
+
+        .actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+        }
+
+        .metrics {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+            gap: 12px;
+            margin-bottom: 20px;
+        }
+
+        .metric,
+        .panel,
+        .card {
+            border: 1px solid var(--border-color-default, #d0d7de);
+            background: var(--background-color-muted, rgba(175, 184, 193, 0.08));
+            border-radius: 12px;
+        }
+
+        .metric {
+            padding: 14px;
+        }
+
+        .metric strong {
+            display: block;
+            font-size: 26px;
+            line-height: 32px;
+        }
+
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+            gap: 16px;
+        }
+
+        .panel {
+            padding: 16px;
+            min-width: 0;
+        }
+
+        .panel-header {
+            display: flex;
+            justify-content: space-between;
+            gap: 12px;
+            margin-bottom: 12px;
+        }
+
+        .stack {
+            display: grid;
+            gap: 10px;
+        }
+
+        .card {
+            padding: 12px;
+            background: var(--background-color-default, #ffffff);
+        }
+
+        .card-title {
+            display: flex;
+            align-items: flex-start;
+            justify-content: space-between;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+
+        .pill-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin: 8px 0;
+        }
+
+        .pill {
+            border: 1px solid var(--border-color-default, #d0d7de);
+            border-radius: 999px;
+            color: var(--text-color-muted, #656d76);
+            padding: 2px 8px;
+            font-size: 12px;
+        }
+
+        .pill.good {
+            color: var(--true-color-green, #1a7f37);
+            border-color: var(--true-color-green-muted, #4ac26b);
+        }
+
+        .pill.warn {
+            color: var(--true-color-red, #cf222e);
+            border-color: var(--true-color-red-muted, #ff8182);
+        }
+
+        .metric.alert strong { color: var(--true-color-red, #cf222e); }
+        .metric.success strong { color: var(--true-color-green, #1a7f37); }
+        .metric.caution strong { color: #9a6700; }
+
+        @keyframes pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.4; }
+        }
+
+        .loading-pulse {
+            animation: pulse 1.4s ease-in-out infinite;
+            color: var(--text-color-muted, #656d76);
+            padding: 40px;
+            text-align: center;
+        }
+
+        .decisions-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: 14px;
+        }
+
+        .decision-group {
+            display: grid;
+            gap: 8px;
+            align-content: start;
+        }
+
+        .decision-group-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            font-weight: var(--font-weight-semibold, 600);
+            font-size: var(--text-body-large, 16px);
+            padding-bottom: 8px;
+            border-bottom: 1px solid var(--border-color-default, #d0d7de);
+        }
+
+        .details {
+            margin: 8px 0 0;
+            padding-left: 18px;
+        }
+
+        .decision-controls {
+            display: grid;
+            gap: 8px;
+            margin-top: 10px;
+        }
+
+        .decision-controls textarea {
+            min-height: 58px;
+            resize: vertical;
+            border: 1px solid var(--border-color-default, #d0d7de);
+            border-radius: 8px;
+            padding: 8px;
+            background: var(--background-color-default, #ffffff);
+            color: var(--text-color-default, #1f2328);
+        }
+
+        .decision-row {
+            display: flex;
+            gap: 8px;
+        }
+
+        .decision-row select {
+            flex: 1;
+            border: 1px solid var(--border-color-default, #d0d7de);
+            border-radius: 8px;
+            padding: 7px;
+            background: var(--background-color-default, #ffffff);
+            color: var(--text-color-default, #1f2328);
+        }
+
+        .summary {
+            margin-top: 18px;
+            padding: 16px;
+            border-left: 4px solid var(--true-color-blue, #0969da);
+            background: var(--true-color-blue-muted, rgba(84, 174, 255, 0.16));
+            border-radius: 8px;
+        }
+
+        .error {
+            padding: 16px;
+            border: 1px solid var(--true-color-red-muted, #ff8182);
+            border-radius: 8px;
+            color: var(--true-color-red, #cf222e);
+        }
+    </style>
+</head>
+<body>
+    <main class="shell">
+        <div class="topbar">
+            <div>
+                <h1>Open Source Friday Producer</h1>
+                <p class="muted">Turn guest request data into next producer actions.</p>
+            </div>
+            <div class="actions">
+                <a id="dashboardLink" class="button" href="https://dash-osf.netlify.app/" target="_blank" rel="noreferrer">Open dashboard</a>
+                <button id="refreshButton" class="button primary" type="button">Refresh</button>
+            </div>
+        </div>
+        <p id="status" class="muted">Loading producer snapshot...</p>
+        <div id="app"></div>
+    </main>
+    <script>
+        const app = document.getElementById("app");
+        const status = document.getElementById("status");
+        const refreshButton = document.getElementById("refreshButton");
+        const dashboardLink = document.getElementById("dashboardLink");
+        let currentState = null;
+
+        refreshButton.addEventListener("click", loadState);
+        loadState();
+
+        async function loadState() {
+            status.textContent = "Loading producer snapshot...";
+            app.innerHTML = '<div class="loading-pulse">Fetching issues from GitHub…</div>';
+
+            try {
+                const response = await fetch("/state", { cache: "no-store" });
+                const payload = await response.json();
+
+                if (!response.ok) {
+                    throw new Error(payload.error || "Could not load producer snapshot.");
+                }
+
+                currentState = payload;
+                dashboardLink.href = payload.dashboardUrl;
+                status.textContent = "Updated " + formatDateTime(payload.generatedAt) + " from " + payload.repository + ".";
+                render(payload);
+            } catch (error) {
+                status.textContent = "";
+                app.innerHTML = '<div class="error">' + escapeHtml(error.message) + '</div>';
+            }
+        }
+
+        function render(state) {
+            app.innerHTML =
+                renderMetrics(state.counts) +
+                renderWarnings(state.warnings) +
+                renderProducerDecisions(state.producerDecisions) +
+                '<div class="grid">' +
+                    renderPending(state.needsMoreInfo) +
+                    renderReady(state.readyToApprove) +
+                    renderApprovedNeedsScheduling(state.approvedNeedsScheduling) +
+                    renderUpcomingSchedule(state.schedule) +
+                    renderScheduleGaps(state.schedule) +
+                    renderAutomation(state.automationOutput) +
+                '</div>' +
+                "";
+
+            bindDecisionControls();
+        }
+
+        function renderMetrics(counts) {
+            return '<section class="metrics">' +
+                metric("Pending", counts.pendingRequests, "") +
+                metric("Ready to approve", counts.readyToApprove, counts.readyToApprove > 0 ? "success" : "") +
+                metric("Need info", counts.needsMoreInfo, counts.needsMoreInfo > 0 ? "caution" : "success") +
+                metric("Approved needs scheduling", counts.approvedNeedsScheduling, counts.approvedNeedsScheduling > 0 ? "caution" : "") +
+                metric("Schedule gaps", counts.scheduleGaps, counts.scheduleGaps > 3 ? "caution" : counts.scheduleGaps === 0 ? "success" : "") +
+                metric("Overbooked dates", counts.overbookedDates, counts.overbookedDates > 0 ? "alert" : "success") +
+            '</section>';
+        }
+
+        function metric(label, value, modifier) {
+            const cls = modifier ? " " + modifier : "";
+            return '<div class="metric' + cls + '"><strong>' + escapeHtml(value) + '</strong><span class="muted">' + escapeHtml(label) + '</span></div>';
+        }
+
+        function renderWarnings(warnings) {
+            if (!warnings || warnings.length === 0) {
+                return "";
+            }
+
+            return '<section class="summary">' +
+                '<strong>Data warning:</strong>' +
+                '<ul class="details">' + warnings.map(function (warning) {
+                    return '<li>' + escapeHtml(warning) + '</li>';
+                }).join("") + '</ul>' +
+            '</section>';
+        }
+
+        function renderPending(items) {
+            return panel("Pending requests", "Needs more info before approval", renderIssueList(items, "needs_info"));
+        }
+
+        function renderReady(items) {
+            return panel("Ready-to-approve guests", "Complete form and repo criteria", renderIssueList(items, "approve"));
+        }
+
+        function renderApprovedNeedsScheduling(items) {
+            return panel("Approved guests needing date or host", "Approved, but not producer-ready yet", renderIssueList(items, "assign_host"));
+        }
+
+        function renderUpcomingSchedule(schedule) {
+            if (schedule.readmeRows.length === 0) {
+                return panel("Upcoming schedule", "From README.md", '<div class="card"><p class="muted">No upcoming rows found in README.md.</p></div>');
+            }
+
+            const rows = schedule.readmeRows.map(function (row) {
+                return '<div class="card"><div class="card-title"><h3>' + escapeHtml(row.date) + '</h3><span class="pill">' + escapeHtml(row.host) + '</span></div>' +
+                    '<p><a href="' + safeUrl(row.url) + '" target="_blank" rel="noreferrer">' + escapeHtml(row.guest) + '</a></p>' +
+                    '<p class="muted">' + escapeHtml(row.project) + '</p></div>';
+            }).join("");
+
+            return panel("Upcoming schedule", "Next " + schedule.readmeRows.length + " stream(s) from README.md", rows);
+        }
+
+        function renderScheduleGaps(schedule) {
+            const collisions = schedule.overbookedDates.map(function (date) {
+                const links = date.issues.map(function (issue) {
+                    return '<a href="' + safeUrl(issue.url) + '" target="_blank" rel="noreferrer">#' + escapeHtml(issue.number) + ' ' + escapeHtml(issue.projectName || issue.title) + '</a>';
+                }).join(" · ");
+                return '<div class="card"><div class="card-title"><h3>' + escapeHtml(date.dateDisplay) + '</h3><span class="pill warn">Collision</span></div><p class="muted">' + links + '</p></div>';
+            }).join("");
+
+            const gaps = schedule.emptyFridays.slice(0, 8).map(function (gap) {
+                return '<div class="card"><div class="card-title"><h3>' + escapeHtml(gap.dateDisplay) + '</h3><span class="pill warn">Gap</span></div><p class="muted">No guest scheduled.</p></div>';
+            }).join("");
+
+            const body = collisions + gaps || '<div class="card"><p class="muted">No gaps or collisions — schedule looks solid.</p></div>';
+            return panel("Gaps & collisions", "Next " + schedule.weeks + " weeks", body);
+        }
+
+        function renderAutomation(items) {
+            const body = items.map(function (item) {
+                const warning = item.warning ? '<p class="pill warn">' + escapeHtml(item.warning) + '</p>' : "";
+                return '<div class="card"><h3>' + escapeHtml(item.name) + '</h3>' +
+                    '<p><strong>Trigger:</strong> ' + escapeHtml(item.trigger) + '</p>' +
+                    '<p><strong>Output:</strong> ' + escapeHtml(item.output) + '</p>' +
+                    '<p class="muted">' + escapeHtml(item.current) + '</p>' + warning + '</div>';
+            }).join("");
+
+            return panel("Automation output", "What labels and workflows will do next", body);
+        }
+
+        function renderProducerDecisions(items) {
+            if (items.length === 0) {
+                return '<section class="panel" style="margin-bottom:16px"><div class="panel-header"><div><h2>Producer decisions</h2><p class="muted">Nothing urgent right now.</p></div></div></section>';
+            }
+
+            const byCategory = new Map();
+            for (const item of items) {
+                const list = byCategory.get(item.category) || [];
+                list.push(item);
+                byCategory.set(item.category, list);
+            }
+
+            const groups = [...byCategory.entries()].map(function (pair) {
+                const category = pair[0];
+                const catItems = pair[1];
+                const cards = catItems.map(function (item) {
+                    const link = item.url ? '<a href="' + safeUrl(item.url) + '" target="_blank" rel="noreferrer">#' + escapeHtml(item.issueNumber) + '</a> ' : "";
+                    const who = item.guestName ? ' <span class="muted">— ' + escapeHtml(item.guestName) + '</span>' : "";
+                    return '<div class="card">' +
+                        '<p>' + link + '<strong>' + escapeHtml(item.title || "") + '</strong>' + who + '</p>' +
+                        '<p class="muted">' + escapeHtml(item.action) + '</p>' +
+                    '</div>';
+                }).join("");
+                return '<div class="decision-group">' +
+                    '<div class="decision-group-header"><span>' + escapeHtml(category) + '</span><span class="pill">' + escapeHtml(catItems.length) + '</span></div>' +
+                    cards +
+                '</div>';
+            }).join("");
+
+            const catCount = byCategory.size;
+            return '<section class="panel" style="margin-bottom:16px">' +
+                '<div class="panel-header"><div><h2>Producer decisions</h2><p class="muted">' + escapeHtml(items.length) + ' item(s) across ' + escapeHtml(catCount) + ' categor' + (catCount === 1 ? 'y' : 'ies') + '</p></div></div>' +
+                '<div class="decisions-grid">' + groups + '</div>' +
+            '</section>';
+        }
+
+        function renderIssueList(items, suggestedDecision) {
+            const body = items.map(function (issue) {
+                return renderIssue(issue, suggestedDecision);
+            }).join("");
+
+            return emptyMessage(body, "Nothing in this bucket.");
+        }
+
+        function renderIssue(issue, suggestedDecision) {
+            const saved = currentState.savedDecisions[String(issue.number)] || {};
+            const decision = saved.decision || suggestedDecision;
+            const ageTag = issue.daysOld != null ? ' <span class="pill" title="Days since submission">' + escapeHtml(issue.daysOld) + 'd</span>' : "";
+            const reasons = issue.readiness && issue.readiness.reasons.length
+                ? '<ul class="details">' + issue.readiness.reasons.map(function (reason) {
+                    return '<li>' + escapeHtml(reason) + '</li>';
+                }).join("") + '</ul>'
+                : "";
+            const checks = issue.repoCheck && issue.repoCheck.checks
+                ? '<div class="pill-row">' + issue.repoCheck.checks.map(function (check) {
+                    return '<span class="pill ' + (check.passed ? "good" : "warn") + '">' + escapeHtml(check.label) + '</span>';
+                }).join("") + '</div>'
+                : "";
+
+            return '<article class="card">' +
+                '<div class="card-title"><h3>' + escapeHtml(issue.projectName || issue.title) + ageTag + '</h3><a href="' + safeUrl(issue.url) + '" target="_blank" rel="noreferrer">#' + escapeHtml(issue.number) + '</a></div>' +
+                '<p><strong>Guest:</strong> ' + escapeHtml(issue.guestName || "TBD") + '</p>' +
+                '<p><strong>Date:</strong> ' + escapeHtml(issue.dateDisplay || "TBD") + '</p>' +
+                '<p><strong>Host:</strong> ' + escapeHtml(issue.hostName || "TBD") + '</p>' +
+                renderLabels(issue.labels) +
+                checks +
+                reasons +
+                renderDecisionControls(issue.number, decision, saved.note || "") +
+            '</article>';
+        }
+
+        function renderLabels(labels) {
+            return '<div class="pill-row">' + labels.map(function (label) {
+                return '<span class="pill">' + escapeHtml(label) + '</span>';
+            }).join("") + '</div>';
+        }
+
+        function renderDecisionControls(issueNumber, decision, note) {
+            return '<div class="decision-controls">' +
+                '<textarea data-note="' + escapeHtml(issueNumber) + '" placeholder="Producer note">' + escapeHtml(note) + '</textarea>' +
+                '<div class="decision-row">' +
+                    '<select data-select="' + escapeHtml(issueNumber) + '">' +
+                        decisionOption("approve", "Approve", decision) +
+                        decisionOption("needs_info", "Needs info", decision) +
+                        decisionOption("assign_host", "Assign host", decision) +
+                        decisionOption("confirm_date", "Confirm date", decision) +
+                        decisionOption("schedule", "Schedule", decision) +
+                        decisionOption("defer", "Defer", decision) +
+                        decisionOption("done", "Done", decision) +
+                    '</select>' +
+                    '<button class="button" type="button" data-save="' + escapeHtml(issueNumber) + '">Save</button>' +
+                '</div>' +
+            '</div>';
+        }
+
+        function decisionOption(value, label, selected) {
+            const selectedText = value === selected ? " selected" : "";
+            return '<option value="' + escapeHtml(value) + '"' + selectedText + '>' + escapeHtml(label) + '</option>';
+        }
+
+        function bindDecisionControls() {
+            document.querySelectorAll("[data-save]").forEach(function (button) {
+                button.addEventListener("click", async function () {
+                    const issueNumber = Number(button.getAttribute("data-save"));
+                    const select = document.querySelector('[data-select="' + issueNumber + '"]');
+                    const note = document.querySelector('[data-note="' + issueNumber + '"]');
+
+                    button.textContent = "Saving...";
+                    button.disabled = true;
+
+                    try {
+                        const response = await fetch("/decision", {
+                            method: "POST",
+                            headers: { "Content-Type": "application/json" },
+                            body: JSON.stringify({
+                                issueNumber: issueNumber,
+                                decision: select.value,
+                                note: note.value,
+                            }),
+                        });
+                        const payload = await response.json();
+                        if (!response.ok) {
+                            throw new Error(payload.error || "Could not save decision.");
+                        }
+                        await new Promise(function (r) { setTimeout(r, 50); });
+                        button.textContent = "Saved ✓";
+                        await new Promise(function (r) { setTimeout(r, 600); });
+                        await loadState();
+                    } catch (error) {
+                        button.textContent = "Save";
+                        button.disabled = false;
+                        alert(error.message);
+                    }
+                });
+            });
+        }
+
+        function panel(title, subtitle, body) {
+            return '<section class="panel"><div class="panel-header"><div><h2>' + escapeHtml(title) + '</h2><p class="muted">' + escapeHtml(subtitle) + '</p></div></div><div class="stack">' + body + '</div></section>';
+        }
+
+        function emptyMessage(body, message) {
+            return body || '<div class="card"><p class="muted">' + escapeHtml(message) + '</p></div>';
+        }
+
+        function formatDateTime(value) {
+            return new Date(value).toLocaleString([], {
+                dateStyle: "medium",
+                timeStyle: "short",
+            });
+        }
+
+        function safeUrl(value) {
+            const text = String(value || "");
+            return text.startsWith("http://") || text.startsWith("https://") ? escapeHtml(text) : "#";
+        }
+
+        function escapeHtml(value) {
+            return String(value ?? "").replace(/[&<>"']/g, function (char) {
+                return {
+                    "&": "&amp;",
+                    "<": "&lt;",
+                    ">": "&gt;",
+                    '"': "&quot;",
+                    "'": "&#39;",
+                }[char];
+            });
+        }
+    </script>
+</body>
+</html>`;
+}


### PR DESCRIPTION
Adds a Copilot CLI project canvas that helps the OSF producer decide what happens next, complementing the dashboard at https://dash-osf.netlify.app/.

## What it does

The canvas loads live data from GitHub and organizes it into producer actions:

- **Pending requests** — flags which need more info before approval, with repo criteria checks (stars, license, CoC, contributing guide)
- **Ready to approve** — guests whose form and repo are complete
- **Approved needs scheduling** — approved guests missing a date or host
- **Upcoming schedule** — next streams from the README.md schedule table
- **Gaps & collisions** — open Fridays and date conflicts in the next 12 weeks
- **Producer decisions** — grouped by category (Approve, Request info, Schedule, Fill gap, Resolve collision) with per-issue decision dropdowns and notes

## Files

```
.github/extensions/osf-producer-canvas/
  extension.mjs      — canvas wiring, loopback server, actions
  producer-data.mjs  — GitHub API fetching, classification, schedule analysis
  renderer.mjs       — full iframe HTML/CSS/JS
```

## How to use

The canvas loads automatically when Copilot CLI is opened in this repo. Ask the agent to open it, or it will appear in the canvas catalog.

For best results, set `GITHUB_TOKEN` (or `GH_TOKEN`) in your shell — unauthenticated API calls are capped at 60/hr.

Per-issue producer decisions are saved locally to `~/.copilot/extensions/osf-producer-canvas/artifacts/`.