### PR TITLE
Remove temporary Sentry connection test from update_schedule

### DIFF
--- a/.github/scripts/update_schedule.py
+++ b/.github/scripts/update_schedule.py
@@ -23,9 +23,6 @@ sentry_sdk.init(
 )
 sentry_sdk.set_tag("workflow", "update-schedule")
 
-# TEST: send a message to verify Sentry is connected — remove after confirming
-sentry_sdk.capture_message("✅ Sentry connected to OSF update-schedule workflow", level="info")
-
 REPO = "githubevents/open-source-friday"
 README_PATH = "README.md"
 START_MARKER = "<!-- SCHEDULE_START -->"


### PR DESCRIPTION
## What

Removes the temporary `capture_message` test line (and its comment) from `update_schedule.py`. It sent an info-level event to Sentry on every run, left over from initial wiring.

## Why

The line was added to confirm Sentry was connected to the update-schedule workflow. The connection is confirmed, so the test now just sends a redundant event on every run. Real error capture still works through the default unhandled-exception handling from `sentry_sdk.init()`, so monitoring is unchanged.

## Verification

- `ast.parse` passes (syntax valid)
- Only 3 lines removed, no behavior change beyond dropping the test event
